### PR TITLE
fix "rebase failed" on non-master base branch

### DIFF
--- a/mergebot.py
+++ b/mergebot.py
@@ -45,6 +45,7 @@ def rebase(pr):
             run(
                 f'git clone https://x-access-token:{os.environ["INPUT_GITHUB_TOKEN"]}@github.com/{repo}.git'
             )
+        run(f"cd {d} && git checkout {pr.base.ref}")
         run(f"cd {d} && git checkout {pr.head.ref}")
         run(f"cd {d} && git rebase {pr.base.ref} --autosquash")
         run(f"cd {d} && git push --force")


### PR DESCRIPTION
On a fresh clone, only `master` is pulled down. If you have some branch B that
is trying to merge into branch A, doing the following doesn't work:
```
git clone $REPO
git checkout B
git rebase A
```
because A does not exist locally.

The fix is simple: first checkout A before checking out B and it will work:
```
git clone $REPO
git checkout A
git checkout B
git rebase A
```