### PR TITLE
fix crash when branch is defined by empty

### DIFF
--- a/mergebot.py
+++ b/mergebot.py
@@ -74,7 +74,7 @@ def mergebot():
         and event["workflow_run"]["pull_requests"]
     ):
         pr_num = event["workflow_run"]["pull_requests"][0]["number"]
-    elif "branches" in event:
+    elif "branches" in event and event["branches"]:
         branch_name = event["branches"][0]["name"]
         pr_num = repo.get_pulls(
             head=f"{os.environ['GITHUB_REPOSITORY_OWNER']}:{branch_name}"


### PR DESCRIPTION
We see github events happen against main where `event["branches"]` is defined,
but is an empty list, leading to a crash when accessing
`event["branches"][0]["name"]`.