### PR TITLE
fix pr check

### DIFF
--- a/mergebot.py
+++ b/mergebot.py
@@ -79,7 +79,7 @@ def mergebot():
         pr = repo.get_pulls(
             head=f"{os.environ['GITHUB_REPOSITORY_OWNER']}:{branch_name}"
         )
-        if not pr:
+        if len(pr) == 0:
             print("no pull requests in this event...")
             return
         pr_num = pr[0].number


### PR DESCRIPTION
pygithub might not implement boolean logic on
`github.PaginatedList.PaginatedList` correctly; we keep seeing this check pass,
but `pr[0]` in the later line failing with a list index error.