### PR TITLE
fix invalid len call for paginated list

### DIFF
--- a/mergebot.py
+++ b/mergebot.py
@@ -79,7 +79,7 @@ def mergebot():
         pr = repo.get_pulls(
             head=f"{os.environ['GITHUB_REPOSITORY_OWNER']}:{branch_name}"
         )
-        if len(pr) == 0:
+        if pr.totalCount == 0:
             print("no pull requests in this event...")
             return
         pr_num = pr[0].number


### PR DESCRIPTION
apparently pygithub paginated lists don't support len() calls. totalCount is
supposed to help here..